### PR TITLE
added {translate} as pair replacement for {_}

### DIFF
--- a/src/main/resources/xmlSources/Latte.xml
+++ b/src/main/resources/xmlSources/Latte.xml
@@ -185,6 +185,11 @@
 				<argument name="class-name" types="PHP_CLASS_NAME" required="true" />
 			</arguments>
 		</tag>
+		<tag name="translate" type="AUTO_EMPTY" allowedFilters="true">
+			<arguments>
+				<argument name="expression" types="PHP_EXPRESSION" validType="string" required="true" />
+			</arguments>
+		</tag>
 		<tag name="try" type="PAIR" />
 		<tag name="rollback" type="UNPAIRED" />
 		<tag name="tag" type="ATTR_ONLY">


### PR DESCRIPTION
More info:
https://github.com/nette/latte/commit/7c87855f5824dedc6be7b0845c7750a9a473d370